### PR TITLE
fix: forbid access to object prototype props in mml parser

### DIFF
--- a/src/parser/parser.test.tsx
+++ b/src/parser/parser.test.tsx
@@ -98,3 +98,9 @@ test('invalid MML', () => {
   const mml = '<input name="test" value=1 />';
   expect(() => SourceToXML(mml)).toThrowError(/Attribute value expected/);
 });
+
+test('forbid access to object prototype props in mml', () => {
+  const mml = '<constructor />';
+  const nodes = SourceToXML(mml);
+  expect(() => XMLtoMMLTree(nodes)).toThrowError(/Converter not found for tag constructor.+/);
+});

--- a/src/parser/tree.ts
+++ b/src/parser/tree.ts
@@ -36,7 +36,7 @@ export class Tree {
 
     (parent.children || []).forEach((child, i) => {
       const converter = this.converters[child.name];
-      if (!converter) {
+      if (!converter || !Object.hasOwnProperty.call(this.converters, child.name)) {
         throw Error(
           `Converter not found for tag ${child.name}, Available converters are ${Object.keys(this.converters)}`,
         );


### PR DESCRIPTION
# Submit a pull request

## CLA

- [x] I have signed the [Stream CLA](https://docs.google.com/forms/d/e/1FAIpQLScFKsKkAJI7mhCr7K9rEIOpqIDThrWxuvxnwUq2XkHyG154vQ/viewform) (required).
- [x] The code changes follow best practices
- [x] Code changes are tested (add some information if not applicable)

## Description of the pull request
MML tags are passed to parser unfiltered and this may expose object(this.converters) prototype props. It can lead to potential execution of malicious code on client's browser. This PR fixes that (test included).