### PR TITLE
ci: run release action on Node 14

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 'lts/*'
+          node-version: '14'
       - name: Install dependencies
         run: yarn install --frozen-lockfile
       - name: Release


### PR DESCRIPTION
### 🎯 Goal

Fix failing package build during the automated release in CI. The failing package is node-sass, which in our version requires Node 14.