### PR TITLE
v0.4.5

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,14 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          {"type": "chore", "scope": "deps", "release": "patch"}
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.4](https://github.com/GetStream/mml-react/releases/tag/v0.4.4) 2022-04-25
+
+### Chore
+* bump axios from 0.21.1 to 0.21.4
+* bump moment from 2.29.1 to 2.29.3
+* bump minimist from 1.2.5 to 1.2.6
+
 ## [0.4.3](https://github.com/GetStream/mml-react/releases/tag/v0.4.3) 2022-04-20
 
 ### Chore

--- a/yarn.lock
+++ b/yarn.lock
@@ -12135,9 +12135,9 @@ minimist-options@4.1.0:
     kind-of "^6.0.3"
 
 minimist@^1.1.0, minimist@^1.1.1, minimist@^1.1.3, minimist@^1.2.0, minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 minipass-collect@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
- chore(deps): bump nanoid from 3.1.20 to 3.3.3
- chore(deps): bump url-parse from 1.5.1 to 1.5.10
- ci: publish new package version if commits of type chore(deps) are present (#54)

