### PR TITLE
chore: use https for repository url

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",
-    "url": "git://github.com/GetStream/mml-react.git"
+    "url": "https://github.com/GetStream/mml-react.git"
   },
   "bugs": {
     "url": "https://github.com/GetStream/mml-react/issues"


### PR DESCRIPTION
## Goal

Use https for repository url. Finishes setting up the automation with semantic-release-cli.