### PR TITLE
v0.4.5

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,5 +23,5 @@ jobs:
       - name: Release
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: yarn semantic-release --branches master main

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,6 +1,14 @@
 {
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "angular",
+        "releaseRules": [
+          {"type": "chore", "scope": "deps", "release": "patch"}
+        ]
+      }
+    ],
     "@semantic-release/release-notes-generator",
     [
       "@semantic-release/changelog",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## [0.4.4](https://github.com/GetStream/mml-react/releases/tag/v0.4.4) 2022-04-25
+
+### Chore
+* bump axios from 0.21.1 to 0.21.4
+* bump moment from 2.29.1 to 2.29.3
+* bump minimist from 1.2.5 to 1.2.6
+
 ## [0.4.3](https://github.com/GetStream/mml-react/releases/tag/v0.4.3) 2022-04-20
 
 ### Chore

--- a/package.json
+++ b/package.json
@@ -35,9 +35,7 @@
     "docs": "docz dev",
     "docs-build": "rm -rf docs && docz build",
     "prepare": "yarn build",
-    "preversion": "yarn install && yarn lint && yarn test",
-    "version": "yarn docs-build && git add -A docs",
-    "postversion": "git push && git push --tags && npm publish",
+    "preversion": "yarn install",
     "semantic-release": "semantic-release"
   },
   "engines": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "license": "SEE LICENSE IN LICENSE",
   "repository": {
     "type": "git",
-    "url": "git://github.com/GetStream/mml-react.git"
+    "url": "https://github.com/GetStream/mml-react.git"
   },
   "bugs": {
     "url": "https://github.com/GetStream/mml-react/issues"

--- a/yarn.lock
+++ b/yarn.lock
@@ -18252,9 +18252,9 @@ url-parse-lax@^3.0.0:
     prepend-http "^2.0.0"
 
 url-parse@^1.1.8, url-parse@^1.4.3, url-parse@^1.4.7:
-  version "1.5.1"
-  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.1.tgz#d5fa9890af8a5e1f274a2c98376510f6425f6e3b"
-  integrity sha512-HOfCOUJt7iSYzEx/UqgtwKRMC6EU91NFhsCHMv9oM03VJcVo2Qrp8T8kI9D7amFf1cu+/3CEhgb3rF9zL7k85Q==
+  version "1.5.10"
+  resolved "https://registry.yarnpkg.com/url-parse/-/url-parse-1.5.10.tgz#9d3c2f736c1d75dd3bd2be507dcc111f1e2ea9c1"
+  integrity sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==
   dependencies:
     querystringify "^2.1.1"
     requires-port "^1.0.0"


### PR DESCRIPTION
- ci: fix issues in automated release configuration (#62)
- chore: remove scripts version, postversion and prevent linting and testing on preversion
- chore(deps): bump url-parse from 1.5.1 to 1.5.10 (#67)
